### PR TITLE
Only prepend baseURL to relative paths

### DIFF
--- a/server/remote/msgraph/call.go
+++ b/server/remote/msgraph/call.go
@@ -22,10 +22,11 @@ func (c *client) Call(method, path string, in, out interface{}) (responseData []
 	if err != nil {
 		return nil, errors.WithMessage(err, errContext)
 	}
-	if len(path) > 0 && path[0] != '/' {
-		path = "/" + path
+
+	// prepend baseURL to relative paths
+	if len(path) > 0 && path[0] == '/' {
+		path = baseURL.String() + path
 	}
-	path = baseURL.String() + path
 
 	var inBody io.Reader
 	if in != nil {
@@ -34,6 +35,7 @@ func (c *client) Call(method, path string, in, out interface{}) (responseData []
 		if err != nil {
 			return nil, err
 		}
+		inBody = buf
 	}
 	req, err := http.NewRequest(method, path, inBody)
 	if err != nil {


### PR DESCRIPTION
#Summary

This PR fixes an issue where full paths, that already contained the baseURL, were getting prepended with the baseURL.  Now, relative paths are determined by looking at the path string and checking that the first character is a `/`.

Also fixed an issue where inBody was not getting set to the buf value, thus alway `nil`.