### PR TITLE
Implement Create Calendar Event Method

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -32,6 +32,8 @@ type Calendar interface {
 	CreateEvent(event *remote.Event) (*remote.Event, error)
 	CreateCalendar(calendar *remote.Calendar) (*remote.Calendar, error)
 	DeleteCalendar(calendarID string) error
+	FindMeetingTimes(meetingParams *remote.FindMeetingTimesParameters) (*remote.MeetingTimeSuggestionResults, error)
+	GetUserCalendars(userID string) ([]*remote.Calendar, error)
 }
 
 type Event interface {

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -30,8 +30,8 @@ type Subscriptions interface {
 type Calendar interface {
 	ViewCalendar(from, to time.Time) ([]*remote.Event, error)
 	CreateEvent(event *remote.Event) (*remote.Event, error)
-	CreateCalendar(calendarName string) (*remote.Calendar, error)
-	DeleteCalendarByID(ID string) error
+	CreateCalendar(calendar *remote.Calendar) (*remote.Calendar, error)
+	DeleteCalendar(calendarID string) error
 }
 
 type Event interface {

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -29,6 +29,9 @@ type Subscriptions interface {
 
 type Calendar interface {
 	ViewCalendar(from, to time.Time) ([]*remote.Event, error)
+	CreateEvent(event *remote.Event) (*remote.Event, error)
+	CreateCalendar(calendarName string) (*remote.Calendar, error)
+	DeleteCalendarByID(ID string) error
 }
 
 type Event interface {

--- a/server/api/calendar.go
+++ b/server/api/calendar.go
@@ -17,3 +17,30 @@ func (api *api) ViewCalendar(from, to time.Time) ([]*remote.Event, error) {
 
 	return client.GetUserDefaultCalendarView(api.user.Remote.ID, from, to)
 }
+
+func (api *api) CreateCalendar(calendarName string) (*remote.Calendar, error) {
+	client, err := api.MakeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.CreateCalendar(calendarName)
+}
+
+func (api *api) CreateEvent(calendarEvent *remote.Event) (*remote.Event, error) {
+	client, err := api.MakeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.CreateEvent(calendarEvent)
+}
+
+func (api *api) DeleteCalendarByID(calendarId string) error {
+	client, err := api.MakeClient()
+	if err != nil {
+		return err
+	}
+
+	return client.DeleteCalendarByID(calendarId)
+}

--- a/server/api/calendar.go
+++ b/server/api/calendar.go
@@ -44,3 +44,23 @@ func (api *api) DeleteCalendar(calendarID string) error {
 
 	return client.DeleteCalendar(calendarID)
 }
+
+func (api *api) FindMeetingTimes(meetingParams *remote.FindMeetingTimesParameters) (*remote.MeetingTimeSuggestionResults, error) {
+	client, err := api.MakeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.FindMeetingTimes(meetingParams)
+}
+
+func (api *api) GetUserCalendars(userID string) ([]*remote.Calendar, error) {
+	client, err := api.MakeClient()
+	if err != nil {
+		return nil, err
+	}
+
+	//DEBUG just use me as the user, for now
+	me, err := client.GetMe()
+	return client.GetUserCalendars(me.ID)
+}

--- a/server/api/calendar.go
+++ b/server/api/calendar.go
@@ -18,13 +18,13 @@ func (api *api) ViewCalendar(from, to time.Time) ([]*remote.Event, error) {
 	return client.GetUserDefaultCalendarView(api.user.Remote.ID, from, to)
 }
 
-func (api *api) CreateCalendar(calendarName string) (*remote.Calendar, error) {
+func (api *api) CreateCalendar(calendar *remote.Calendar) (*remote.Calendar, error) {
 	client, err := api.MakeClient()
 	if err != nil {
 		return nil, err
 	}
 
-	return client.CreateCalendar(calendarName)
+	return client.CreateCalendar(calendar)
 }
 
 func (api *api) CreateEvent(calendarEvent *remote.Event) (*remote.Event, error) {
@@ -36,11 +36,11 @@ func (api *api) CreateEvent(calendarEvent *remote.Event) (*remote.Event, error) 
 	return client.CreateEvent(calendarEvent)
 }
 
-func (api *api) DeleteCalendarByID(calendarId string) error {
+func (api *api) DeleteCalendar(calendarID string) error {
 	client, err := api.MakeClient()
 	if err != nil {
 		return err
 	}
 
-	return client.DeleteCalendarByID(calendarId)
+	return client.DeleteCalendar(calendarID)
 }

--- a/server/plugin/command/command.go
+++ b/server/plugin/command/command.go
@@ -65,6 +65,12 @@ func (c *Command) Handle() (string, error) {
 		handler = c.connect
 	case "viewcal":
 		handler = c.viewCalendar
+	case "createcal":
+		handler = c.createCalendar
+	case "createevent":
+		handler = c.createEvent
+	case "deletecal":
+		handler = c.deleteCalendar
 	case "subscribe":
 		handler = c.subscribe
 	}

--- a/server/plugin/command/command.go
+++ b/server/plugin/command/command.go
@@ -67,7 +67,7 @@ func (c *Command) Handle() (string, error) {
 		handler = c.viewCalendar
 	case "createcal":
 		handler = c.createCalendar
-	case "createevent":
+	case "testcreateevent":
 		handler = c.createEvent
 	case "deletecal":
 		handler = c.deleteCalendar

--- a/server/plugin/command/command.go
+++ b/server/plugin/command/command.go
@@ -73,6 +73,10 @@ func (c *Command) Handle() (string, error) {
 		handler = c.deleteCalendar
 	case "subscribe":
 		handler = c.subscribe
+	case "findMeetings":
+		handler = c.findMeetings
+	case "showcals":
+		handler = c.showCalendars
 	}
 	out, err := handler(parameters...)
 	if err != nil {

--- a/server/plugin/command/create_calendar.go
+++ b/server/plugin/command/create_calendar.go
@@ -2,6 +2,8 @@ package command
 
 import (
 	"fmt"
+
+	"github.com/mattermost/mattermost-plugin-msoffice/server/remote"
 )
 
 func (c *Command) createCalendar(parameters ...string) (string, error) {
@@ -9,10 +11,13 @@ func (c *Command) createCalendar(parameters ...string) (string, error) {
 		return "Please provide the name of one calendar to create", nil
 	}
 
-	calendar, err := c.API.CreateCalendar(parameters[0])
+	calIn := &remote.Calendar{
+		Name: parameters[0],
+	}
+
+	calOut, err := c.API.CreateCalendar(calIn)
 	if err != nil {
 		return "", err
 	}
-	fmt.Printf("calendar = %+v\n", calendar)
-	return "", nil
+	return fmt.Sprintf("Created Calendar \"%+v\"\n", calOut.Name), nil
 }

--- a/server/plugin/command/create_calendar.go
+++ b/server/plugin/command/create_calendar.go
@@ -1,0 +1,18 @@
+package command
+
+import (
+	"fmt"
+)
+
+func (c *Command) createCalendar(parameters ...string) (string, error) {
+	if len(parameters) != 1 {
+		return "Please provide the name of one calendar to create", nil
+	}
+
+	calendar, err := c.API.CreateCalendar(parameters[0])
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("calendar = %+v\n", calendar)
+	return "", nil
+}

--- a/server/plugin/command/create_calendar.go
+++ b/server/plugin/command/create_calendar.go
@@ -1,8 +1,6 @@
 package command
 
 import (
-	"fmt"
-
 	"github.com/mattermost/mattermost-plugin-msoffice/server/remote"
 )
 
@@ -15,9 +13,9 @@ func (c *Command) createCalendar(parameters ...string) (string, error) {
 		Name: parameters[0],
 	}
 
-	calOut, err := c.API.CreateCalendar(calIn)
+	_, err := c.API.CreateCalendar(calIn)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("Created Calendar \"%+v\"\n", calOut.Name), nil
+	return "", nil
 }

--- a/server/plugin/command/create_event.go
+++ b/server/plugin/command/create_event.go
@@ -1,33 +1,30 @@
 package command
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-plugin-msoffice/server/remote"
 	"github.com/mattermost/mattermost-plugin-msoffice/server/utils"
+	flag "github.com/spf13/pflag"
 )
 
-func (c *Command) createEvent(parameters ...string) (string, error) {
-	// if len(parameters) != 2 {
-	// 	// return "jason", errors.New("Please specify an issue kassignee>`.")
-	// 	return "Run `/msoffice` for general help or `/msoffice viewcal` to get calendar id", nil
-	// }
+func getCreateEventFlagSet() *flag.FlagSet {
+	flagSet := flag.NewFlagSet("create", flag.ContinueOnError)
+	flagSet.String("subject", "", "Subject of the Event (no spaces for now)")
+	flagSet.String("starttime", time.Now().Format(time.RFC3339), "Start time for the event")
+	flagSet.String("endtime", time.Now().Add(time.Hour).Format(time.RFC3339), "End time for the event")
+	flagSet.StringSlice("attendees", []string{}, "A comma separated list of Attendees")
 
-	// subject := parameters[0]
-	// body := parameters[1]
-	// calId := parameters[2]
+	return flagSet
+}
 
-	// parse start time
-	start := &remote.DateTime{
-		TimeZone: "Pacific Standard Time",
-		DateTime: time.Now().Format(time.RFC3339),
-	}
+type userError struct {
+	ErrorMessage string
+}
 
-	// parse end time
-	end := &remote.DateTime{
-		TimeZone: "Pacific Standard Time",
-		DateTime: time.Now().Add(time.Hour).Format(time.RFC3339),
-	}
+func parseCreateArgs(args []string) (*remote.Event, *userError, error) {
 
 	var attendees []*remote.Attendee
 
@@ -60,7 +57,7 @@ func (c *Command) createEvent(parameters ...string) (string, error) {
 
 	// create event
 	event := &remote.Event{
-		Subject: "testsubject",
+		Subject: "TestSubject",
 		// BodyPreview: "testBodyPreview",
 		BodyPreview: "DEBUG_BodyPreview",
 		Body: &remote.ItemBody{
@@ -69,14 +66,14 @@ func (c *Command) createEvent(parameters ...string) (string, error) {
 		},
 		ReminderMinutesBeforeStart: 15,
 		Location: &remote.Location{
-			DisplayName:  "Home",
+			DisplayName:  "Las Vegas",
 			LocationType: "homeAddress",
 			Address: &remote.Address{
-				Street:          "E Main St",
-				City:            "Redmond",
-				State:           "WA",
+				Street:          "3730 Las Vegas Blvd S",
+				City:            "Las Vegas",
+				State:           "Nevada",
 				CountryOrRegion: "US",
-				PostalCode:      "32008",
+				PostalCode:      "89158",
 			},
 			Coordinates: &remote.Coordinates{
 				Latitude:  47.672,
@@ -84,8 +81,82 @@ func (c *Command) createEvent(parameters ...string) (string, error) {
 			},
 		},
 		Attendees: attendees,
-		Start:     start,
-		End:       end,
+		Start: &remote.DateTime{
+			TimeZone: "Pacific Standard Time",
+			DateTime: time.Now().Format(time.RFC3339),
+		},
+		End: &remote.DateTime{
+			TimeZone: "Pacific Standard Time",
+			DateTime: time.Now().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	// parse flags and start overriding Demo Defaults
+	createFlagSet := getCreateEventFlagSet()
+	err := createFlagSet.Parse(args)
+	if err != nil {
+		return event, nil, err
+	}
+
+	//                //
+	// Required Flags //
+	//                //
+	subject, err := createFlagSet.GetString("subject")
+	if err != nil {
+		return event, nil, err
+	}
+	// check that next arg is not a flag "--"
+	if subject == "" || strings.HasPrefix(subject, "--") {
+		return event, &userError{ErrorMessage: "must specify an event subject"}, nil
+	}
+	event.Subject = subject
+
+	//                //
+	// Optional Flags //
+	//                //
+	startTime, err := createFlagSet.GetString("starttime")
+	if err != nil {
+		return event, nil, err
+	}
+	if strings.HasPrefix(startTime, "--") {
+		return event, &userError{ErrorMessage: "must specify an event subject"}, nil
+	}
+	event.Start.DateTime = startTime
+
+	endTime, err := createFlagSet.GetString("endtime")
+	if err != nil {
+		return event, nil, err
+	}
+	if strings.HasPrefix(endTime, "--") {
+		return event, &userError{ErrorMessage: "must specify an event subject"}, nil
+	}
+	event.End.DateTime = endTime
+	// for a := range event.myattendees {
+	// 	fmt.Printf("myattendees[a] = %+v\n", myattendees[a])
+	// }
+	// attendees, err := createFlagSet.GetStringSlice("attendees")
+	// if err != nil {
+	// 	return "", nil, nil, err
+	// }
+	// if len(attendees) == 0 {
+	// 	return "must specify some attendees ", nil, nil, nil
+	// }
+
+	return event, nil, nil
+}
+
+func (c *Command) createEvent(parameters ...string) (string, error) {
+
+	if len(parameters) == 0 {
+		return fmt.Sprintf(getCreateEventFlagSet().FlagUsages()), nil
+	}
+
+	event, userError, err := parseCreateArgs(parameters)
+	if err != nil {
+		return "", err
+	}
+	if userError != nil {
+		return string(userError.ErrorMessage), nil
 	}
 
 	calEvent, err := c.API.CreateEvent(event)

--- a/server/plugin/command/create_event.go
+++ b/server/plugin/command/create_event.go
@@ -29,9 +29,9 @@ func (c *Command) createEvent(parameters ...string) (string, error) {
 		DateTime: time.Now().Add(time.Hour).Format(time.RFC3339),
 	}
 
-	var attendees []*remote.EventAttendee
+	var attendees []*remote.Attendee
 
-	attendee1 := &remote.EventAttendee{
+	attendee1 := &remote.Attendee{
 		Type: "required",
 		Status: &remote.EventResponseStatus{
 			Response: "",
@@ -43,7 +43,7 @@ func (c *Command) createEvent(parameters ...string) (string, error) {
 		},
 	}
 
-	attendee2 := &remote.EventAttendee{
+	attendee2 := &remote.Attendee{
 		Type: "required",
 		Status: &remote.EventResponseStatus{
 			Response: "",
@@ -68,17 +68,17 @@ func (c *Command) createEvent(parameters ...string) (string, error) {
 			ContentType: "Text",
 		},
 		ReminderMinutesBeforeStart: 15,
-		Location: &remote.EventLocation{
+		Location: &remote.Location{
 			DisplayName:  "Home",
 			LocationType: "homeAddress",
-			Address: &remote.EventAddress{
+			Address: &remote.Address{
 				Street:          "E Main St",
 				City:            "Redmond",
 				State:           "WA",
 				CountryOrRegion: "US",
 				PostalCode:      "32008",
 			},
-			Coordinates: &remote.EventCoordinates{
+			Coordinates: &remote.Coordinates{
 				Latitude:  47.672,
 				Longitude: -102.103,
 			},

--- a/server/plugin/command/create_event.go
+++ b/server/plugin/command/create_event.go
@@ -1,0 +1,98 @@
+package command
+
+import (
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-msoffice/server/remote"
+	"github.com/mattermost/mattermost-plugin-msoffice/server/utils"
+)
+
+func (c *Command) createEvent(parameters ...string) (string, error) {
+	// if len(parameters) != 2 {
+	// 	// return "jason", errors.New("Please specify an issue kassignee>`.")
+	// 	return "Run `/msoffice` for general help or `/msoffice viewcal` to get calendar id", nil
+	// }
+
+	// subject := parameters[0]
+	// body := parameters[1]
+	// calId := parameters[2]
+
+	// parse start time
+	start := &remote.DateTime{
+		TimeZone: "Pacific Standard Time",
+		DateTime: time.Now().Format(time.RFC3339),
+	}
+
+	// parse end time
+	end := &remote.DateTime{
+		TimeZone: "Pacific Standard Time",
+		DateTime: time.Now().Add(time.Hour).Format(time.RFC3339),
+	}
+
+	var attendees []*remote.EventAttendee
+
+	attendee1 := &remote.EventAttendee{
+		Type: "required",
+		Status: &remote.EventResponseStatus{
+			Response: "",
+			Time:     "",
+		},
+		EmailAddress: &remote.EmailAddress{
+			Address: "joe@example.com",
+			Name:    "joe smith",
+		},
+	}
+
+	attendee2 := &remote.EventAttendee{
+		Type: "required",
+		Status: &remote.EventResponseStatus{
+			Response: "",
+			Time:     "",
+		},
+		EmailAddress: &remote.EmailAddress{
+			Address: "jane@example.com",
+			Name:    "jane smith",
+		},
+	}
+
+	attendees = append(attendees, attendee1)
+	attendees = append(attendees, attendee2)
+
+	// create event
+	event := &remote.Event{
+		Subject: "testsubject",
+		// BodyPreview: "testBodyPreview",
+		BodyPreview: "DEBUG_BodyPreview",
+		Body: &remote.ItemBody{
+			Content:     "Hello!  Here is the start of Your Body!",
+			ContentType: "Text",
+		},
+		ReminderMinutesBeforeStart: 15,
+		Location: &remote.EventLocation{
+			DisplayName:  "Home",
+			LocationType: "homeAddress",
+			Address: &remote.EventAddress{
+				Street:          "E Main St",
+				City:            "Redmond",
+				State:           "WA",
+				CountryOrRegion: "US",
+				PostalCode:      "32008",
+			},
+			Coordinates: &remote.EventCoordinates{
+				Latitude:  47.672,
+				Longitude: -102.103,
+			},
+		},
+		Attendees: attendees,
+		Start:     start,
+		End:       end,
+	}
+
+	calEvent, err := c.API.CreateEvent(event)
+	if err != nil {
+		return "", err
+	}
+	resp := "Event Created\n" + utils.JSONBlock(&calEvent)
+
+	return resp, nil
+}

--- a/server/plugin/command/delete_calendar.go
+++ b/server/plugin/command/delete_calendar.go
@@ -1,7 +1,5 @@
 package command
 
-import "fmt"
-
 func (c *Command) deleteCalendar(parameters ...string) (string, error) {
 	if len(parameters) != 1 {
 		return "Please provide the ID of only one calendar ", nil
@@ -11,5 +9,5 @@ func (c *Command) deleteCalendar(parameters ...string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("Deleted Calendar \"%+v\"\n", parameters[0]), nil
+	return "", nil
 }

--- a/server/plugin/command/delete_calendar.go
+++ b/server/plugin/command/delete_calendar.go
@@ -1,0 +1,13 @@
+package command
+
+func (c *Command) deleteCalendar(parameters ...string) (string, error) {
+	if len(parameters) != 1 {
+		return "Please provide the ID of only one calendar ", nil
+	}
+
+	err := c.API.DeleteCalendarByID(parameters[0])
+	if err != nil {
+		return "", err
+	}
+	return "", nil
+}

--- a/server/plugin/command/delete_calendar.go
+++ b/server/plugin/command/delete_calendar.go
@@ -5,7 +5,7 @@ func (c *Command) deleteCalendar(parameters ...string) (string, error) {
 		return "Please provide the ID of only one calendar ", nil
 	}
 
-	err := c.API.DeleteCalendarByID(parameters[0])
+	err := c.API.DeleteCalendar(parameters[0])
 	if err != nil {
 		return "", err
 	}

--- a/server/plugin/command/delete_calendar.go
+++ b/server/plugin/command/delete_calendar.go
@@ -1,5 +1,7 @@
 package command
 
+import "fmt"
+
 func (c *Command) deleteCalendar(parameters ...string) (string, error) {
 	if len(parameters) != 1 {
 		return "Please provide the ID of only one calendar ", nil
@@ -9,5 +11,5 @@ func (c *Command) deleteCalendar(parameters ...string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return "", nil
+	return fmt.Sprintf("Deleted Calendar \"%+v\"\n", parameters[0]), nil
 }

--- a/server/plugin/command/find_meeting_times.go
+++ b/server/plugin/command/find_meeting_times.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mattermost/mattermost-plugin-msoffice/server/remote"
+	"github.com/mattermost/mattermost-plugin-msoffice/server/utils"
+)
+
+func (c *Command) findMeetings(parameters ...string) (string, error) {
+	meetingParams := &remote.FindMeetingTimesParameters{}
+	// meetings, err := c.API.FindMeetingTimes(time.Now(), time.Now().Add(14*24*time.Hour))
+	meetings, err := c.API.FindMeetingTimes(meetingParams)
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Printf("meetings = %+v\n", meetings)
+	meetingsD, _ := json.MarshalIndent(meetings, "", "    ")
+	fmt.Printf("meetings = %+v\n", string(meetingsD))
+
+	resp := ""
+	for _, m := range meetings.MeetingTimeSuggestions {
+		resp += "  - " + utils.JSONBlock(m)
+	}
+
+	return resp, nil
+}

--- a/server/plugin/command/get_calendars.go
+++ b/server/plugin/command/get_calendars.go
@@ -1,0 +1,11 @@
+package command
+
+func (c *Command) showCalendars(parameters ...string) (string, error) {
+
+	_, err := c.API.GetUserCalendars("")
+	if err != nil {
+		return "", err
+	}
+
+	return "", nil
+}

--- a/server/plugin/command/help.go
+++ b/server/plugin/command/help.go
@@ -18,15 +18,14 @@ func (c *Command) help(parameters ...string) (string, error) {
 		c.Config.BuildHash,
 		c.Config.BuildDate)
 	resp += "\n"
-	resp += "TODO help\n"
-	resp += "/msoffice\n"
-	resp += "/msoffice connect\n"
-	resp += "/msoffice help\n"
-	resp += "/msoffice info\n"
-	resp += "/msoffice viewcal\n"
-	resp += "/msoffice subscribe\n"
-	resp += "/msoffice createcal <name>\n"
-	resp += "/msoffice deletecal <id>\n"
-	resp += "/msoffice createevent <Subject> <Start> <End> <Reminder (minutes)>\n"
+	resp += "* /msoffice\n"
+	resp += "* /msoffice connect\n"
+	resp += "* /msoffice help\n"
+	resp += "* /msoffice info\n"
+	resp += "* /msoffice viewcal\n"
+	resp += "* /msoffice subscribe\n"
+	resp += "* /msoffice createcal <name>\n"
+	resp += "* /msoffice deletecal <id>\n"
+	resp += "* /msoffice testcreateevent\n"
 	return resp, nil
 }

--- a/server/plugin/command/help.go
+++ b/server/plugin/command/help.go
@@ -18,6 +18,15 @@ func (c *Command) help(parameters ...string) (string, error) {
 		c.Config.BuildHash,
 		c.Config.BuildDate)
 	resp += "\n"
-	resp += "TODO help"
+	resp += "TODO help\n"
+	resp += "/msoffice\n"
+	resp += "/msoffice connect\n"
+	resp += "/msoffice help\n"
+	resp += "/msoffice info\n"
+	resp += "/msoffice viewcal\n"
+	resp += "/msoffice subscribe\n"
+	resp += "/msoffice createcal <name>\n"
+	resp += "/msoffice deletecal <id>\n"
+	resp += "/msoffice createevent <Subject> <Start> <End> <Reminder (minutes)>\n"
 	return resp, nil
 }

--- a/server/plugin/command/help.go
+++ b/server/plugin/command/help.go
@@ -19,10 +19,11 @@ func (c *Command) help(parameters ...string) (string, error) {
 		c.Config.BuildDate)
 	resp += "\n"
 	resp += "* /msoffice\n"
-	resp += "* /msoffice connect\n"
 	resp += "* /msoffice help\n"
 	resp += "* /msoffice info\n"
+	resp += "* /msoffice connect\n"
 	resp += "* /msoffice viewcal\n"
+	resp += "* /msoffice showcals\n"
 	resp += "* /msoffice subscribe\n"
 	resp += "* /msoffice createcal <name>\n"
 	resp += "* /msoffice deletecal <id>\n"

--- a/server/plugin/http/oauth2_connect.go
+++ b/server/plugin/http/oauth2_connect.go
@@ -4,8 +4,9 @@
 package http
 
 import (
-	"github.com/mattermost/mattermost-plugin-msoffice/server/api"
 	"net/http"
+
+	"github.com/mattermost/mattermost-plugin-msoffice/server/api"
 )
 
 func (h *Handler) oauth2Connect(w http.ResponseWriter, r *http.Request) {

--- a/server/remote/client.go
+++ b/server/remote/client.go
@@ -11,9 +11,9 @@ type Client interface {
 	CreateSubscription(notificationURL string) (*Subscription, error)
 	DeclineUserEvent(userID, eventID string) error
 	DeleteSubscription(subscriptionID string) error
-	CreateCalendar(calendarName string) (*Calendar, error)
+	CreateCalendar(calendar *Calendar) (*Calendar, error)
 	CreateEvent(calendarEvent *Event) (*Event, error)
-	DeleteCalendarByID(calendarID string) error
+	DeleteCalendar(calendarID string) error
 	GetMe() (*User, error)
 	GetNotificationData(*Notification) (*Notification, error)
 	GetUserCalendars(userID string) ([]*Calendar, error)

--- a/server/remote/client.go
+++ b/server/remote/client.go
@@ -12,6 +12,7 @@ type Client interface {
 	DeclineUserEvent(userID, eventID string) error
 	DeleteSubscription(subscriptionID string) error
 	CreateCalendar(calendar *Calendar) (*Calendar, error)
+	FindMeetingTimes(meetingParams *FindMeetingTimesParameters) (*MeetingTimeSuggestionResults, error)
 	CreateEvent(calendarEvent *Event) (*Event, error)
 	DeleteCalendar(calendarID string) error
 	GetMe() (*User, error)

--- a/server/remote/client.go
+++ b/server/remote/client.go
@@ -11,6 +11,9 @@ type Client interface {
 	CreateSubscription(notificationURL string) (*Subscription, error)
 	DeclineUserEvent(userID, eventID string) error
 	DeleteSubscription(subscriptionID string) error
+	CreateCalendar(calendarName string) (*Calendar, error)
+	CreateEvent(calendarEvent *Event) (*Event, error)
+	DeleteCalendarByID(calendarID string) error
 	GetMe() (*User, error)
 	GetNotificationData(*Notification) (*Notification, error)
 	GetUserCalendars(userID string) ([]*Calendar, error)

--- a/server/remote/event.go
+++ b/server/remote/event.go
@@ -18,10 +18,10 @@ type Event struct {
 	Start                      *DateTime            `json:"start,omitempty"`
 	End                        *DateTime            `json:"end,omitempty"`
 	ReminderMinutesBeforeStart int32                `json:"reminderMinutesBeforeStart,omitempty"`
-	Location                   *EventLocation       `json:"location,omitempty"`
+	Location                   *Location            `json:"location,omitempty"`
 	ResponseStatus             *EventResponseStatus `json:"responseStatus,omitempty"`
-	Attendees                  []*EventAttendee     `json:"attendees,omitempty"`
-	Organizer                  *EventAttendee       `json:"organizer,omitempty"`
+	Attendees                  []*Attendee          `json:"attendees,omitempty"`
+	Organizer                  *Attendee            `json:"organizer,omitempty"`
 }
 
 type ItemBody struct {
@@ -34,14 +34,14 @@ type EventResponseStatus struct {
 	Time     string `json:"time,omitempty"`
 }
 
-type EventLocation struct {
-	DisplayName  string            `json:"displayName,omitempty"`
-	Address      *EventAddress     `json:"address"`
-	Coordinates  *EventCoordinates `json:"coordinates"`
-	LocationType string            `json:"locationType"`
+type Location struct {
+	DisplayName  string       `json:"displayName,omitempty"`
+	Address      *Address     `json:"address"`
+	Coordinates  *Coordinates `json:"coordinates"`
+	LocationType string       `json:"locationType"`
 }
 
-type EventAddress struct {
+type Address struct {
 	Street          string `json:"street,omitempty"`
 	City            string `json:"city,omitempty"`
 	State           string `json:"state,omitempty"`
@@ -49,12 +49,12 @@ type EventAddress struct {
 	PostalCode      string `json:"postalCode,omitempty"`
 }
 
-type EventCoordinates struct {
+type Coordinates struct {
 	Latitude  float32 `json:"latitude,omitempty"`
 	Longitude float32 `json:"longitude,omitempty"`
 }
 
-type EventAttendee struct {
+type Attendee struct {
 	Type         string               `json:"type,omitempty"`
 	Status       *EventResponseStatus `json:"status,omitempty"`
 	EmailAddress *EmailAddress        `json:"emailAddress,omitempty"`

--- a/server/remote/event.go
+++ b/server/remote/event.go
@@ -4,22 +4,29 @@
 package remote
 
 type Event struct {
-	ID                string               `json:"id"`
-	Subject           string               `json:"subject,omitempty"`
-	BodyPreview       string               `json:"bodyPreview,omitempty"`
-	Importance        string               `json:"importance,omitempty"`
-	IsAllDay          bool                 `json:"isAllDay,omitempty"`
-	IsCancelled       bool                 `json:"isCancelled,omitempty"`
-	IsOrganizer       bool                 `json:"isOrganizer,omitempty"`
-	ResponseRequested bool                 `json:"responseRequested,omitempty"`
-	ShowAs            string               `json:"showAs,omitempty"`
-	Weblink           string               `json:"weblink,omitempty"`
-	Start             *DateTime            `json:"start,omitempty"`
-	End               *DateTime            `json:"end,omitempty"`
-	Location          *EventLocation       `json:"location,omitempty"`
-	ResponseStatus    *EventResponseStatus `json:"responseStatus,omitempty"`
-	Attendees         []*EventAttendee     `json:"attendees,omitempty"`
-	Organizer         *EventAttendee       `json:"organizer,omitempty"`
+	ID                         string               `json:"id,omitempty"`
+	Subject                    string               `json:"subject,omitempty"`
+	BodyPreview                string               `json:"bodyPreview,omitempty"`
+	Body                       *ItemBody            `json:"Body,omitempty"`
+	Importance                 string               `json:"importance,omitempty"`
+	IsAllDay                   bool                 `json:"isAllDay,omitempty"`
+	IsCancelled                bool                 `json:"isCancelled,omitempty"`
+	IsOrganizer                bool                 `json:"isOrganizer,omitempty"`
+	ResponseRequested          bool                 `json:"responseRequested,omitempty"`
+	ShowAs                     string               `json:"showAs,omitempty"`
+	Weblink                    string               `json:"weblink,omitempty"`
+	Start                      *DateTime            `json:"start,omitempty"`
+	End                        *DateTime            `json:"end,omitempty"`
+	ReminderMinutesBeforeStart int32                `json:"reminderMinutesBeforeStart,omitempty"`
+	Location                   *EventLocation       `json:"location,omitempty"`
+	ResponseStatus             *EventResponseStatus `json:"responseStatus,omitempty"`
+	Attendees                  []*EventAttendee     `json:"attendees,omitempty"`
+	Organizer                  *EventAttendee       `json:"organizer,omitempty"`
+}
+
+type ItemBody struct {
+	Content     string `json:"content,omitempty"`
+	ContentType string `json:"contentType,omitempty"`
 }
 
 type EventResponseStatus struct {
@@ -28,7 +35,23 @@ type EventResponseStatus struct {
 }
 
 type EventLocation struct {
-	DisplayName string `json:"displayName,omitempty"`
+	DisplayName  string            `json:"displayName,omitempty"`
+	Address      *EventAddress     `json:"address"`
+	Coordinates  *EventCoordinates `json:"coordinates"`
+	LocationType string            `json:"locationType"`
+}
+
+type EventAddress struct {
+	Street          string `json:"street,omitempty"`
+	City            string `json:"city,omitempty"`
+	State           string `json:"state,omitempty"`
+	CountryOrRegion string `json:"countryOrRegion,omitempty"`
+	PostalCode      string `json:"postalCode,omitempty"`
+}
+
+type EventCoordinates struct {
+	Latitude  float32 `json:"latitude,omitempty"`
+	Longitude float32 `json:"longitude,omitempty"`
 }
 
 type EventAttendee struct {

--- a/server/remote/event.go
+++ b/server/remote/event.go
@@ -3,6 +3,8 @@
 
 package remote
 
+import "time"
+
 type Event struct {
 	ID                         string               `json:"id,omitempty"`
 	Subject                    string               `json:"subject,omitempty"`
@@ -58,4 +60,59 @@ type Attendee struct {
 	Type         string               `json:"type,omitempty"`
 	Status       *EventResponseStatus `json:"status,omitempty"`
 	EmailAddress *EmailAddress        `json:"emailAddress,omitempty"`
+}
+
+// TODO possibly move some of these, non-event types to remote/common.go
+
+// Type = *AttendeeType = options (Required, Optional, Resource)
+type AttendeeBase struct {
+	Recipient *EmailAddress
+	Type      string `json:"type,omitempty"`
+}
+
+type FindMeetingTimesParameters struct {
+	Attendees                 []AttendeeBase      `json:"attendees,omitempty"`
+	LocationConstraint        *LocationConstraint `json:"locationConstraint,omitempty"`
+	TimeConstraint            *TimeConstraint     `json:"timeConstraint,omitempty"`
+	MeetingDuration           *time.Duration      `json:"meetingDuration,omitempty"`
+	MaxCandidates             *int                `json:"maxCandidates,omitempty"`
+	IsOrganizerOptional       *bool               `json:"isOrganizerOptional,omitempty"`
+	ReturnSuggestionReasons   *bool               `json:"returnSuggestionReasons,omitempty"`
+	MinimumAttendeePercentage *float64            `json:"minimumAttendeePercentage,omitempty"`
+}
+
+// *ActivityDomain= options (Unknown, Work, Personal, Unrestricted)
+type TimeConstraint struct {
+	ActivityDomain string     `json:"activityDomain,omitempty"`
+	TimeSlots      []TimeSlot `json:"timeSlots,omitempty"`
+}
+type MeetingTimeSuggestion struct {
+	AttendeeAvailability  string
+	confidence            float32
+	locations             []*Location
+	meetingTimeSlot       *TimeSlot
+	order                 int32
+	organizerAvailability string
+	suggestionReason      string
+}
+
+type MeetingTimeSuggestionResults struct {
+	MeetingTimeSuggestions []*MeetingTimeSuggestion
+	emptySuggestionReason  string
+}
+
+type TimeSlot struct {
+	Start *DateTime `json:"start,omitempty"`
+	End   *DateTime `json:"end,omitempty"`
+}
+
+type LocationConstraint struct {
+	Locations       []LocationConstraintItem `json:"locations,omitempty"`
+	IsRequired      *bool                    `json:"isRequired,omitempty"`
+	SuggestLocation *bool                    `json:"suggestLocation,omitempty"`
+}
+
+type LocationConstraintItem struct {
+	Location            *Location
+	ResolveAvailability *bool `json:"resolveAvailability,omitempty"`
 }

--- a/server/remote/msgraph/create_calendar.go
+++ b/server/remote/msgraph/create_calendar.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package msgraph
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mattermost/mattermost-plugin-msoffice/server/remote"
+)
+
+// CreateCalendar creates a calendar
+func (c *client) CreateCalendar(calendarName string) (*remote.Calendar, error) {
+	var calendar = &remote.Calendar{
+		Name: calendarName,
+	}
+	var calOut = remote.Calendar{}
+	req := c.rbuilder.Me().Calendars().Request()
+	err := req.JSONRequest(c.ctx, http.MethodPost, "", &calendar, &calOut)
+
+	calD, _ := json.MarshalIndent(calOut, "", "    ")
+	fmt.Printf("cal = %+v\n", string(calD))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &calOut, nil
+}

--- a/server/remote/msgraph/create_calendar.go
+++ b/server/remote/msgraph/create_calendar.go
@@ -12,20 +12,15 @@ import (
 )
 
 // CreateCalendar creates a calendar
-func (c *client) CreateCalendar(calendarName string) (*remote.Calendar, error) {
-	var calendar = &remote.Calendar{
-		Name: calendarName,
-	}
+func (c *client) CreateCalendar(calIn *remote.Calendar) (*remote.Calendar, error) {
 	var calOut = remote.Calendar{}
-	req := c.rbuilder.Me().Calendars().Request()
-	err := req.JSONRequest(c.ctx, http.MethodPost, "", &calendar, &calOut)
-
-	calD, _ := json.MarshalIndent(calOut, "", "    ")
-	fmt.Printf("cal = %+v\n", string(calD))
-
+	err := c.rbuilder.Me().Calendars().Request().JSONRequest(c.ctx, http.MethodPost, "", &calIn, &calOut)
 	if err != nil {
 		return nil, err
 	}
+
+	calD, _ := json.MarshalIndent(calOut, "", "    ")
+	fmt.Printf("cal = %+v\n", string(calD))
 
 	return &calOut, nil
 }

--- a/server/remote/msgraph/create_calendar.go
+++ b/server/remote/msgraph/create_calendar.go
@@ -4,11 +4,10 @@
 package msgraph
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/mattermost/mattermost-plugin-msoffice/server/remote"
+	"github.com/mattermost/mattermost-plugin-msoffice/server/utils/bot"
 )
 
 // CreateCalendar creates a calendar
@@ -18,9 +17,8 @@ func (c *client) CreateCalendar(calIn *remote.Calendar) (*remote.Calendar, error
 	if err != nil {
 		return nil, err
 	}
-
-	calD, _ := json.MarshalIndent(calOut, "", "    ")
-	fmt.Printf("cal = %+v\n", string(calD))
-
+	c.Logger.With(bot.LogContext{
+		"v": calOut,
+	}).Infof("msgraph: CreateCalendars created the following calendar.")
 	return &calOut, nil
 }

--- a/server/remote/msgraph/create_event.go
+++ b/server/remote/msgraph/create_event.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package msgraph
+
+import (
+	"net/http"
+
+	"github.com/mattermost/mattermost-plugin-msoffice/server/remote"
+)
+
+// CreateEvent creates a calendar event
+func (c *client) CreateEvent(calendarEvent *remote.Event) (*remote.Event, error) {
+	var eventOut = remote.Event{}
+	req := c.rbuilder.Me().Events().Request()
+	err := req.JSONRequest(c.ctx, http.MethodPost, "", &calendarEvent, &eventOut)
+	if err != nil {
+		return nil, err
+	}
+	return &eventOut, nil
+}

--- a/server/remote/msgraph/create_event.go
+++ b/server/remote/msgraph/create_event.go
@@ -10,12 +10,11 @@ import (
 )
 
 // CreateEvent creates a calendar event
-func (c *client) CreateEvent(calendarEvent *remote.Event) (*remote.Event, error) {
-	var eventOut = remote.Event{}
-	req := c.rbuilder.Me().Events().Request()
-	err := req.JSONRequest(c.ctx, http.MethodPost, "", &calendarEvent, &eventOut)
+func (c *client) CreateEvent(in *remote.Event) (*remote.Event, error) {
+	var out = remote.Event{}
+	err := c.rbuilder.Me().Events().Request().JSONRequest(c.ctx, http.MethodPost, "", &in, &out)
 	if err != nil {
 		return nil, err
 	}
-	return &eventOut, nil
+	return &out, nil
 }

--- a/server/remote/msgraph/delete_calendar.go
+++ b/server/remote/msgraph/delete_calendar.go
@@ -3,10 +3,10 @@
 
 package msgraph
 
-func (c *client) DeleteCalendarByID(calendarID string) error {
+func (c *client) DeleteCalendar(calID string) error {
 	// TODO: Implement
 
-	err := c.rbuilder.Me().Calendars().ID(calendarID).Request().Delete(c.ctx)
+	err := c.rbuilder.Me().Calendars().ID(calID).Request().Delete(c.ctx)
 	if err != nil {
 		return err
 	}

--- a/server/remote/msgraph/delete_calendar.go
+++ b/server/remote/msgraph/delete_calendar.go
@@ -3,10 +3,13 @@
 
 package msgraph
 
+import "github.com/mattermost/mattermost-plugin-msoffice/server/utils/bot"
+
 func (c *client) DeleteCalendar(calID string) error {
 	err := c.rbuilder.Me().Calendars().ID(calID).Request().Delete(c.ctx)
 	if err != nil {
 		return err
 	}
+	c.Logger.With(bot.LogContext{}).Infof("msgraph: DeleteCalendar deleted calendar `%v`.", calID)
 	return nil
 }

--- a/server/remote/msgraph/delete_calendar.go
+++ b/server/remote/msgraph/delete_calendar.go
@@ -4,12 +4,9 @@
 package msgraph
 
 func (c *client) DeleteCalendar(calID string) error {
-	// TODO: Implement
-
 	err := c.rbuilder.Me().Calendars().ID(calID).Request().Delete(c.ctx)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/server/remote/msgraph/delete_calendar.go
+++ b/server/remote/msgraph/delete_calendar.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package msgraph
+
+func (c *client) DeleteCalendarByID(calendarID string) error {
+	// TODO: Implement
+
+	err := c.rbuilder.Me().Calendars().ID(calendarID).Request().Delete(c.ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/server/remote/msgraph/find_meeting_times.go
+++ b/server/remote/msgraph/find_meeting_times.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package msgraph
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mattermost/mattermost-plugin-msoffice/server/remote"
+	msgraph "github.com/yaegashi/msgraph.go/v1.0"
+)
+
+// FindMeetingTimes finds Meetinsa calendar event
+func (c *client) FindMeetingTimes(findMeetingsParam *remote.FindMeetingTimesParameters) (*remote.MeetingTimeSuggestionResults, error) {
+	meetingsOut := &remote.MeetingTimeSuggestionResults{}
+	fakeReq := &msgraph.UserFindMeetingTimesRequestParameter{}
+	fakeRes := &msgraph.MeetingTimeSuggestionsResult{}
+
+	req := c.rbuilder.Me().FindMeetingTimes(fakeReq).Request()
+	err := req.JSONRequest(c.ctx, http.MethodPost, "", &findMeetingsParam, &fakeRes)
+
+	fakeReqD, _ := json.MarshalIndent(fakeReq, "", "    ")
+	fmt.Printf("fakeReq = %+v\n", string(fakeReqD))
+
+	fakeResD, _ := json.MarshalIndent(fakeRes, "", "    ")
+	fmt.Printf("fakeRes = %+v\n", string(fakeResD))
+
+	if err != nil {
+		return nil, err
+	}
+	return meetingsOut, nil
+}

--- a/server/remote/msgraph/get_user_calendars.go
+++ b/server/remote/msgraph/get_user_calendars.go
@@ -22,6 +22,7 @@ func (c *client) GetUserCalendars(userID string) ([]*remote.Calendar, error) {
 	}
 	c.Logger.With(bot.LogContext{
 		"UserID": userID,
+		"v":      v.Value,
 	}).Infof("msgraph: GetUserCalendars returned `%d` calendars.", len(v.Value))
 	return v.Value, nil
 }


### PR DESCRIPTION
**Draft PR**

The main objective of this PR is to implement the `createEvent()` method.

Additionally, the PR adds the following:
* new subtypes to the `Event` Struct
* `CreateCalendar()` method and slash command
* `DeleteCalendar()` method and slash command
* more help text for available slash commands

**Additional Notes About the Draft PR**

While debugging the `CreateEvent()` method, I have been hardcoding the values into the `Event` struct, rather than implementing the slash command parsing.  Please assume additional commits to have similar hard-coded types until debugging is finished.
